### PR TITLE
Fixes for keyboard controls

### DIFF
--- a/source/GameSettings.cpp
+++ b/source/GameSettings.cpp
@@ -10,6 +10,7 @@
 #include "cDMAudio.h"
 #include "Main.h"
 #include "CHud.h"
+#include "Settings.h"
 
 #pragma comment(lib, "shlwapi")
 
@@ -26,18 +27,46 @@ void CGameSettings::Clear(bool clearOnly) {
     }
 
     // Controls
-    controlKeys[CONTROLKEY_FORWARD] = DIK_W;
-    controlKeys[CONTROLKEY_BACKWARD] = DIK_S;
-    controlKeys[CONTROLKEY_LEFT] = DIK_A;
-    controlKeys[CONTROLKEY_RIGHT] = DIK_D;
-    controlKeys[CONTROLKEY_ATTACK] = DIK_LMB;
-    controlKeys[CONTROLKEY_ENTEROREXIT] = DIK_F;
-    controlKeys[CONTROLKEY_HANDBRAKEORJUMP] = DIK_SPACE;
-    controlKeys[CONTROLKEY_PREVWEAPON] = DIK_WHEELDN;
-    controlKeys[CONTROLKEY_NEXTWEAPON] = DIK_WHEELUP;
-    controlKeys[CONTROLKEY_SPECIAL1] = DIK_TAB;
-    controlKeys[CONTROLKEY_SPECIAL2] = DIK_LCONTROL;
-    controlKeys[CONTROLKEY_UNKNOWN] = DIK_RSHIFT;
+    if (settings.DefaultControls == Settings::DEFAULT_CONTROLS_ORIGINAL) {
+        controlKeys[CONTROLKEY_FORWARD] = DIK_UP;
+        controlKeys[CONTROLKEY_BACKWARD] = DIK_DOWN;
+        controlKeys[CONTROLKEY_LEFT] = DIK_LEFT;
+        controlKeys[CONTROLKEY_RIGHT] = DIK_RIGHT;
+        controlKeys[CONTROLKEY_ATTACK] = DIK_LCONTROL;
+        controlKeys[CONTROLKEY_ENTEROREXIT] = DIK_RETURN;
+        controlKeys[CONTROLKEY_HANDBRAKEORJUMP] = DIK_SPACE;
+        controlKeys[CONTROLKEY_PREVWEAPON] = DIK_Z;
+        controlKeys[CONTROLKEY_NEXTWEAPON] = DIK_X;
+        controlKeys[CONTROLKEY_SPECIAL1] = DIK_TAB;
+        controlKeys[CONTROLKEY_SPECIAL2] = DIK_LMENU;
+        controlKeys[CONTROLKEY_UNKNOWN] = DIK_RSHIFT;
+    } else if (settings.DefaultControls == Settings::DEFAULT_CONTROLS_CLASSIC) {
+        controlKeys[CONTROLKEY_FORWARD] = DIK_U;
+        controlKeys[CONTROLKEY_BACKWARD] = DIK_I;
+        controlKeys[CONTROLKEY_LEFT] = DIK_Z;
+        controlKeys[CONTROLKEY_RIGHT] = DIK_X;
+        controlKeys[CONTROLKEY_ATTACK] = DIK_SPACE;
+        controlKeys[CONTROLKEY_ENTEROREXIT] = DIK_W;
+        controlKeys[CONTROLKEY_HANDBRAKEORJUMP] = DIK_P;
+        controlKeys[CONTROLKEY_PREVWEAPON] = DIK_LSHIFT;
+        controlKeys[CONTROLKEY_NEXTWEAPON] = DIK_TAB;
+        controlKeys[CONTROLKEY_SPECIAL1] = DIK_S;
+        controlKeys[CONTROLKEY_SPECIAL2] = DIK_A;
+        controlKeys[CONTROLKEY_UNKNOWN] = DIK_RSHIFT;
+    } else {
+        controlKeys[CONTROLKEY_FORWARD] = DIK_W;
+        controlKeys[CONTROLKEY_BACKWARD] = DIK_S;
+        controlKeys[CONTROLKEY_LEFT] = DIK_A;
+        controlKeys[CONTROLKEY_RIGHT] = DIK_D;
+        controlKeys[CONTROLKEY_ATTACK] = DIK_LMB;
+        controlKeys[CONTROLKEY_ENTEROREXIT] = DIK_F;
+        controlKeys[CONTROLKEY_HANDBRAKEORJUMP] = DIK_SPACE;
+        controlKeys[CONTROLKEY_PREVWEAPON] = DIK_WHEELDN;
+        controlKeys[CONTROLKEY_NEXTWEAPON] = DIK_WHEELUP;
+        controlKeys[CONTROLKEY_SPECIAL1] = DIK_TAB;
+        controlKeys[CONTROLKEY_SPECIAL2] = DIK_LCONTROL;
+        controlKeys[CONTROLKEY_UNKNOWN] = DIK_RSHIFT;
+    }
 
     // Audio
     sfxVolume = 87;

--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -601,6 +601,84 @@ const wchar_t* dinputKeyNames[DIK_MEDIASELECT + 1 + 5] = {
     L"WHEELDN",
 };
 
+const int dinputAllowedKeys[] = {
+    DIK_1,          // 0x02
+    DIK_2,          // 0x03
+    DIK_3,          // 0x04
+    DIK_4,          // 0x05
+    DIK_5,          // 0x06
+    DIK_6,          // 0x07
+    DIK_7,          // 0x08
+    DIK_8,          // 0x09
+    DIK_9,          // 0x0A
+    DIK_0,          // 0x0B
+    DIK_MINUS,      // 0x0C
+    DIK_EQUALS,     // 0x0D
+    DIK_BACK,       // 0x0E
+    DIK_TAB,        // 0x0F
+    DIK_Q,          // 0x10
+    DIK_W,          // 0x11
+    DIK_E,          // 0x12
+    DIK_R,          // 0x13
+    DIK_T,          // 0x14
+    DIK_Y,          // 0x15
+    DIK_U,          // 0x16
+    DIK_I,          // 0x17
+    DIK_O,          // 0x18
+    DIK_P,          // 0x19
+    DIK_LBRACKET,   // 0x1A
+    DIK_RBRACKET,   // 0x1B
+    DIK_RETURN,     // 0x1C
+    DIK_LCONTROL,   // 0x1D
+    DIK_A,          // 0x1E
+    DIK_S,          // 0x1F
+    DIK_D,          // 0x20
+    DIK_F,          // 0x21
+    DIK_G,          // 0x22
+    DIK_H,          // 0x23
+    DIK_J,          // 0x24
+    DIK_K,          // 0x25
+    DIK_L,          // 0x26
+    DIK_SEMICOLON,  // 0x27
+    DIK_APOSTROPHE, // 0x28
+    DIK_GRAVE,      // 0x29
+    DIK_LSHIFT,     // 0x2A
+    DIK_BACKSLASH,  // 0x2B
+    DIK_Z,          // 0x2C
+    DIK_X,          // 0x2D
+    DIK_C,          // 0x2E
+    DIK_V,          // 0x2F
+    DIK_B,          // 0x30
+    DIK_N,          // 0x31
+    DIK_M,          // 0x32
+    DIK_COMMA,      // 0x33
+    DIK_PERIOD,     // 0x34
+    DIK_SLASH,      // 0x35
+    DIK_RSHIFT,     // 0x36
+    DIK_MULTIPLY,   // 0x37
+    DIK_LMENU,      // 0x38
+    DIK_SPACE,      // 0x39
+    DIK_CAPITAL,    // 0x3A
+    DIK_NUMPAD7,    // 0x47
+    DIK_NUMPAD8,    // 0x48
+    DIK_NUMPAD9,    // 0x49
+    DIK_NUMPAD4,    // 0x4B
+    DIK_NUMPAD5,    // 0x4C
+    DIK_NUMPAD6,    // 0x4D
+    DIK_NUMPAD1,    // 0x4F
+    DIK_NUMPAD2,    // 0x50
+    DIK_NUMPAD3,    // 0x51
+    DIK_NUMPAD0,    // 0x52
+    DIK_RCONTROL,   // 0x9D
+    DIK_RMENU,      // 0xB8
+    DIK_UP,         // 0xC8
+    DIK_LEFT,       // 0xCB
+    DIK_RIGHT,      // 0xCD
+    DIK_DOWN,       // 0xD0
+};
+
+const unsigned int dinputAllowedKeysLength = sizeof(dinputAllowedKeys) / sizeof(int);
+
 static int menuColorPulse = 255;
 
 injector::hook_back<void(__stdcall*)(int, int, int, int, int, int, int, int, int, char, char)> hbDrawSprite;
@@ -1386,14 +1464,14 @@ public:
             if (redefineKey) {
                 _this->m_MenuPages[_this->m_nCurrentMenuPage].currentMenuItem = previousMenuItem;
 
-#define NOTTHISKEY (i != DIK_DELETE && !(i >= DIK_F1 && i <= DIK_SCROLL) && i != DIK_SUBTRACT && i != DIK_ADD && !(i >= DIK_DECIMAL && i <= DIK_F12))
-                for (unsigned int i = DIK_1; i < DIK_F12; i++) {
-                    if (newKeys[i] && !oldKeys[i] && NOTTHISKEY) {
+                for (unsigned int i = 0; i < dinputAllowedKeysLength; i++) {
+                    int key = dinputAllowedKeys[i];
+                    if (newKeys[key] && !oldKeys[key]) {
                         PlayFrontendSound(_this, 7);
-                        gameSettings.controlKeys[_this->m_MenuPages[_this->m_nCurrentMenuPage].currentMenuItem] = i;
+                        gameSettings.controlKeys[_this->m_MenuPages[_this->m_nCurrentMenuPage].currentMenuItem] = key;
                         gameSettings.Save();
 
-                        UnboundDoubleKeys(_this, i);
+                        UnboundDoubleKeys(_this, key);
                         redefineKey = false;
                         return;
                     }

--- a/source/Settings.cpp
+++ b/source/Settings.cpp
@@ -9,5 +9,6 @@ void Settings::Read() {
     EnablePauseMenu = config["EnablePauseMenu"].asBool();
     EnableLoadingScreen = config["EnableLoadingScreen"].asBool();
     ClipMousePosition = config["ClipMousePosition"].asBool();
+    DefaultControls = config["DefaultControls"].asInt(DEFAULT_CONTROLS_FRONTEND_FIX);
 
 }

--- a/source/Settings.h
+++ b/source/Settings.h
@@ -2,12 +2,19 @@
 
 class Settings {
 public:
+    static const int DEFAULT_CONTROLS_FRONTEND_FIX = 0;
+    static const int DEFAULT_CONTROLS_ORIGINAL = 1;
+    static const int DEFAULT_CONTROLS_CLASSIC = 2;
+
     // AvailPatch
     bool EnablePauseMenu;
     bool EnableLoadingScreen;
 
     // Mouse
     bool ClipMousePosition;
+
+    // Controls
+    int DefaultControls = DEFAULT_CONTROLS_FRONTEND_FIX;
 
 public:
     void Read();


### PR DESCRIPTION
Added two patches with fixes for keyboard controls.

The first one fixes an issue were it was not possible to select certain keys, e.g. the arrows keys, when configuring keyboard controls in-game. I have tested it quite a bit but I'm not certain I got it completely right. I used the `dinput.h` file from the glfw project as reference https://github.com/glfw/glfw/blob/master/deps/mingw/dinput.h. I think I excluded all of the keys mentioned in the `NOTTHISKEY` macro but maybe I missed some.

The second adds the default controls which are present in the GTA2 Manager as options which can be selected in the settings file `FrontendFixII.ini`.

![GTA2 Manager](https://github.com/gennariarmando/gta2-frontend-fix/assets/2266099/36c94df6-8be5-49ae-a637-41d38cebcf55)

The settings file is not present in the repository but something similar to this could maybe be added to the settings file in the release package:

```
; Select default keyboard controls.
; 0 = FrontendFix
; 1 = Original
; 2 = Classic
DefaultControls = 0
```