### PR TITLE
Don't move window when ALT-tabbing

### DIFF
--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -2529,7 +2529,7 @@ public:
                 rect.right += extraWidth;
                 rect.bottom += extraHeight;
                 SetWindowLong(GetHWnd(), GWL_STYLE, WS_VISIBLE | (WS_OVERLAPPEDWINDOW & ~WS_SIZEBOX));
-                SetWindowPos(GetHWnd(), HWND_NOTOPMOST, rect.left, rect.top, rect.right, rect.bottom, 0);
+                SetWindowPos(GetHWnd(), HWND_NOTOPMOST, rect.left, rect.top, rect.right, rect.bottom, SWP_NOMOVE);
             }
             else if (start_mode == 2) {
                 SetWindowLongPtr(GetHWnd(), GWL_STYLE, WS_VISIBLE | WS_POPUP);


### PR DESCRIPTION
Currently when running the application in windowed mode the window is centered every time it regains focus. Passing the `SWP_NOMOVE` flag to `SetWindowPos` in `Main.cpp` on line 2532 seems to cause the window to remain in place. This is something I found annoying when ALT-tabbing the game although I don't know if it is intended behavior or not.